### PR TITLE
build: fix broken golangci-lint.sh location #patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ lint:
 		-w /code \
 		golang:$(GO_VERSION) \
 		sh -c "\
-		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /go/bin $(GO_CI_VERSION) && \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /go/bin $(GO_CI_VERSION) && \
 		golangci-lint -v run --exclude-use-default=false --deadline 5m \
 			-E golint \
 			-E gosec \


### PR DESCRIPTION
golangci-lint.sh was pulled from https://install.goreleaser.com/github.com/golangci/golangci-lint.sh.
install.goreleaser.com throws a ssl error .preventing builds from succeeding. 
This updates to use github.com so the builds succeed.