### PR TITLE
Add support for fully qualified SSM ARNs in cross-account parameters #minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /coverage.*
 version_wf
 .DS_Store
+
+.idea

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_VERSION ?= 1.18
+GO_VERSION ?= 1.24
 GO_CI_VERSION = v1.55.0
 BINARIES = aws-env
 WD ?= $(shell pwd)

--- a/awsenv/file_replacer_test.go
+++ b/awsenv/file_replacer_test.go
@@ -348,5 +348,5 @@ func writeTempFile(contents string) (string, func()) {
 		log.Fatal(err)
 	}
 
-	return tmpfile.Name(), func() { os.Remove(fName) } //nolint: errcheck,gosec
+	return tmpfile.Name(), func() { os.Remove(tmpfile.Name()) } //nolint: errcheck,gosec
 }

--- a/awsenv/file_replacer_test.go
+++ b/awsenv/file_replacer_test.go
@@ -3,6 +3,7 @@ package awsenv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -64,6 +65,24 @@ mysql_users:
 		active = 1,
 		admin_username = "awsenv:/path/to/the/username",
 		admin_password = "awsenv:/path/to/the/password",
+	}
+ )
+`
+	sampleCnfFile5 = `
+mysql_users:
+ (
+	{
+		username = "awsenv:arn:aws:ssm:us-east-1:123456789012:parameter/remote/username",
+		password = "awsenv:arn:aws:ssm:us-east-1:123456789012:parameter/remote/password",
+	}
+ )
+`
+	sampleCnfFile6 = `
+mysql_users:
+ (
+	{
+		username = "awsenv:/path/to/the/username",
+		password = "awsenv:arn:aws:ssm:us-east-1:123456789012:parameter/remote/password",
 	}
  )
 `
@@ -205,6 +224,101 @@ mysql_users:
 		active = 1,
 		admin_username = "user",
 		admin_password = "password",
+	}
+ )
+`
+	f, err := ioutil.ReadFile(fileName) //nolint: gosec
+	require.NoError(t, err)
+
+	require.Equal(t, expectedContent, string(f))
+}
+
+func TestFileReplacer_ReplaceAll_CrossAccountARN(t *testing.T) {
+
+	fileName, cleanup := writeTempFile(sampleCnfFile5)
+	defer cleanup()
+
+	oldContent, err := ioutil.ReadFile(fileName) //nolint: gosec
+	require.NoError(t, err)
+	require.Equal(t, sampleCnfFile5, string(oldContent))
+
+	// Use mockParamsGetter to simulate SSM's behavior of stripping ARN prefixes from result keys
+	getter := mockParamsGetter(func(_ context.Context, paths []string) (map[string]string, error) {
+		store := map[string]string{
+			"/remote/username": "remote_user",
+			"/remote/password": "remote_pass",
+		}
+		result := make(map[string]string, len(paths))
+		for _, p := range paths {
+			plain := stripARNPrefix(p)
+			val, ok := store[plain]
+			if !ok {
+				return nil, fmt.Errorf("not found: %s", p)
+			}
+			result[plain] = val
+		}
+		return result, nil
+	})
+
+	r := NewFileReplacer(DefaultPrefix, fileName, getter)
+
+	ctx := context.Background()
+	err = r.ReplaceAll(ctx)
+	require.NoError(t, err, "expected no error")
+
+	expectedContent := `
+mysql_users:
+ (
+	{
+		username = "remote_user",
+		password = "remote_pass",
+	}
+ )
+`
+	f, err := ioutil.ReadFile(fileName) //nolint: gosec
+	require.NoError(t, err)
+
+	require.Equal(t, expectedContent, string(f))
+}
+
+func TestFileReplacer_ReplaceAll_MixedLocalAndCrossAccount(t *testing.T) {
+
+	fileName, cleanup := writeTempFile(sampleCnfFile6)
+	defer cleanup()
+
+	oldContent, err := ioutil.ReadFile(fileName) //nolint: gosec
+	require.NoError(t, err)
+	require.Equal(t, sampleCnfFile6, string(oldContent))
+
+	getter := mockParamsGetter(func(_ context.Context, paths []string) (map[string]string, error) {
+		store := map[string]string{
+			"/path/to/the/username": "local_user",
+			"/remote/password":      "remote_pass",
+		}
+		result := make(map[string]string, len(paths))
+		for _, p := range paths {
+			plain := stripARNPrefix(p)
+			val, ok := store[plain]
+			if !ok {
+				return nil, fmt.Errorf("not found: %s", p)
+			}
+			result[plain] = val
+		}
+		return result, nil
+	})
+
+	r := NewFileReplacer(DefaultPrefix, fileName, getter)
+
+	ctx := context.Background()
+	err = r.ReplaceAll(ctx)
+	require.NoError(t, err, "expected no error")
+
+	expectedContent := `
+mysql_users:
+ (
+	{
+		username = "local_user",
+		password = "remote_pass",
 	}
  )
 `

--- a/awsenv/helpers.go
+++ b/awsenv/helpers.go
@@ -1,5 +1,18 @@
 package awsenv
 
+import "regexp"
+
+// ssmARNPrefix matches the fully qualified SSM parameter ARN prefix used for cross-account parameters.
+//
+//	example: `arn:aws:ssm:<region>:<account_id>:parameter<parameter_path>`
+var ssmARNPrefix = regexp.MustCompile(`arn:aws:ssm:[^:]+:[^:]+:parameter`)
+
+// stripARNPrefix removes the SSM ARN prefix from a parameter path, returning the plain path.
+// If the path does not contain an ARN prefix, it is returned unchanged.
+func stripARNPrefix(path string) string {
+	return ssmARNPrefix.ReplaceAllString(path, "")
+}
+
 func min(x, y int) int {
 	if x < y {
 		return x

--- a/awsenv/helpers.go
+++ b/awsenv/helpers.go
@@ -3,6 +3,7 @@ package awsenv
 import "regexp"
 
 // ssmARNPrefix matches the fully qualified SSM parameter ARN prefix used for cross-account parameters.
+// note: this will not cover AWS GovCloud ARNs
 //
 //	example: `arn:aws:ssm:<region>:<account_id>:parameter<parameter_path>`
 var ssmARNPrefix = regexp.MustCompile(`arn:aws:ssm:[^:]+:[^:]+:parameter`)

--- a/awsenv/helpers_test.go
+++ b/awsenv/helpers_test.go
@@ -83,6 +83,42 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+func TestStripARNPrefix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain_path",
+			input: "/my/param/path",
+			want:  "/my/param/path",
+		},
+		{
+			name:  "full_arn",
+			input: "arn:aws:ssm:us-east-1:123456789012:parameter/my/param/path",
+			want:  "/my/param/path",
+		},
+		{
+			name:  "empty_string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := stripARNPrefix(test.input)
+			if got != test.want {
+				t.Errorf("stripARNPrefix(%q) = %q, want %q", test.input, got, test.want)
+			}
+		})
+	}
+}
+
 func TestChunk(t *testing.T) {
 	tests := []struct {
 		size  int

--- a/awsenv/replacer.go
+++ b/awsenv/replacer.go
@@ -128,6 +128,8 @@ func (r *Replacer) applyParamPathValues(srcEnv map[string]string, replaceWithVal
 		}
 
 		lookupValue := strings.TrimPrefix(value, r.prefix)
+		// values from the env will still include the fully qualified prefix, but the replacement will not
+		lookupValue = stripARNPrefix(lookupValue)
 		if val, ok := replaceWithValues[lookupValue]; ok {
 			srcEnv[name] = val
 		}
@@ -171,6 +173,9 @@ func fetch(ctx context.Context, ssm ParamsGetter, paths []string) (map[string]st
 	merge(dest, results)
 
 	for _, path := range paths {
+		// results from GetParams include only the path (not fully qualified), but the original paths include the fully
+		// qualified name.
+		path = stripARNPrefix(path)
 		_, ok := dest[path]
 		if !ok {
 			return dest, errors.Errorf("awsenv: param not found: %q", path)

--- a/awsenv/replacer_test.go
+++ b/awsenv/replacer_test.go
@@ -352,9 +352,9 @@ func TestReplacer_applyParamPathValues(t *testing.T) {
 		},
 	}
 
-	for idx, test := range tests {
+	for _, test := range tests {
 		test := test
-		t.Run(fmt.Sprintf(test.name, idx), func(t *testing.T) {
+		t.Run(fmt.Sprintf(test.name), func(t *testing.T) {
 			t.Parallel()
 			r := &Replacer{prefix: test.prefix}
 			got, want := r.applyParamPathValues(test.src, test.replaceWithValues), test.want

--- a/awsenv/replacer_test.go
+++ b/awsenv/replacer_test.go
@@ -354,7 +354,7 @@ func TestReplacer_applyParamPathValues(t *testing.T) {
 
 	for _, test := range tests {
 		test := test
-		t.Run(fmt.Sprintf(test.name), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			r := &Replacer{prefix: test.prefix}
 			got, want := r.applyParamPathValues(test.src, test.replaceWithValues), test.want


### PR DESCRIPTION
## Overview

Adds support for using fully qualified AWS SSM parameter ARNs (e.g.,
`arn:aws:ssm:us-east-1:123456789012:parameter/path/to/secret`) in addition to plain parameter paths. This enables
cross-account parameter lookups where the full ARN is required to reference parameters in other AWS accounts.

## Changes

- Added `stripARNPrefix` helper that extracts the plain parameter path from a fully qualified SSM ARN
- Updated `FileReplacer` to track the original path (including ARN) alongside the plain path used for replacement
  lookups, so the correct number of characters is replaced in the output
- Updated `Replacer` to strip ARN prefixes when matching SSM response keys back to environment variable values
- Updated `fetch` to strip ARN prefixes when checking for missing parameters in SSM results
- Expanded `splitPath` to allow `:` in paths so ARN strings are not split prematurely
- Added tests for cross-account ARN replacement, mixed local/cross-account scenarios, and the `stripARNPrefix` helper
- Fixed a minor bug in `writeTempFile` where the cleanup closure captured the wrong variable
- Bumped Go version from 1.18 to 1.24 in Makefile
- Replaced `t.Parallel()` in replacer tests that mutate globals with proper `t.Cleanup` to restore state

## Impact

Users can now reference SSM parameters from other AWS accounts by specifying the full ARN in the `awsenv:` prefix.
Existing plain path usage is unaffected.

---
_Description written by Claude_